### PR TITLE
Remove console.log

### DIFF
--- a/src/make_custom_element.js
+++ b/src/make_custom_element.js
@@ -6,7 +6,6 @@ export function make_custom_element(
   observedAttributes,
   superclassTag
 ) {
-  console.log('superclass = ', superclass, tag_name, shadow, constructor, observedAttributes, superclassTag);
 
   customElements.define(
     tag_name,


### PR DESCRIPTION
Fixes https://github.com/gbj/custom-elements/issues/2

Choosing to straight up remove the `console.log` as you can fire off `log` methods from within the `connectedCallback` for runtime debugging.